### PR TITLE
PVADMIN-50329: Fix CVE-2026-41706, CVE-2026-41003, CVE-2026-40988, CVE-2026-41694, CVE-2026-47838

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/X509Configurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/X509Configurer.java
@@ -160,7 +160,10 @@ public final class X509Configurer<H extends HttpSecurityBuilder<H>>
 	 * @param subjectPrincipalRegex the regex to extract the user principal from the
 	 * certificate (i.e. "CN=(.*?)(?:,|$)").
 	 * @return the {@link X509Configurer} for further customizations
+	 * @deprecated Please use {@link #x509PrincipalExtractor(X509PrincipalExtractor)}
+	 * instead
 	 */
+	@Deprecated
 	public X509Configurer<H> subjectPrincipalRegex(String subjectPrincipalRegex) {
 		SubjectDnX509PrincipalExtractor principalExtractor = new SubjectDnX509PrincipalExtractor();
 		principalExtractor.setSubjectDnRegex(subjectPrincipalRegex);

--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -101,7 +101,7 @@ import org.springframework.security.oauth2.server.resource.web.access.server.Bea
 import org.springframework.security.oauth2.server.resource.web.server.BearerTokenServerAuthenticationEntryPoint;
 import org.springframework.security.oauth2.server.resource.web.server.authentication.ServerBearerTokenAuthenticationConverter;
 import org.springframework.security.web.PortMapper;
-import org.springframework.security.web.authentication.preauth.x509.SubjectDnX509PrincipalExtractor;
+import org.springframework.security.web.authentication.preauth.x509.SubjectX500PrincipalExtractor;
 import org.springframework.security.web.authentication.preauth.x509.X509PrincipalExtractor;
 import org.springframework.security.web.server.DefaultServerRedirectStrategy;
 import org.springframework.security.web.server.DelegatingServerAuthenticationEntryPoint;
@@ -826,8 +826,8 @@ public class ServerHttpSecurity {
 	 *  }
 	 * </pre>
 	 *
-	 * Note that if extractor is not specified, {@link SubjectDnX509PrincipalExtractor}
-	 * will be used. If authenticationManager is not specified,
+	 * Note that if extractor is not specified, {@link SubjectX500PrincipalExtractor} will
+	 * be used. If authenticationManager is not specified,
 	 * {@link ReactivePreAuthenticatedAuthenticationManager} will be used.
 	 * @return the {@link X509Spec} to customize
 	 * @since 5.2
@@ -856,8 +856,8 @@ public class ServerHttpSecurity {
 	 *  }
 	 * </pre>
 	 *
-	 * Note that if extractor is not specified, {@link SubjectDnX509PrincipalExtractor}
-	 * will be used. If authenticationManager is not specified,
+	 * Note that if extractor is not specified, {@link SubjectX500PrincipalExtractor} will
+	 * be used. If authenticationManager is not specified,
 	 * {@link ReactivePreAuthenticatedAuthenticationManager} will be used.
 	 * @param x509Customizer the {@link Customizer} to provide more options for the
 	 * {@link X509Spec}
@@ -3429,7 +3429,7 @@ public class ServerHttpSecurity {
 			if (this.principalExtractor != null) {
 				return this.principalExtractor;
 			}
-			return new SubjectDnX509PrincipalExtractor();
+			return new SubjectX500PrincipalExtractor();
 		}
 
 		private ReactiveAuthenticationManager getAuthenticationManager() {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/X509ConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/X509ConfigurerTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.SecurityContextChangedListenerConfig;
@@ -38,11 +39,14 @@ import org.springframework.security.config.test.SpringTestContextExtension;
 import org.springframework.security.core.context.SecurityContextChangedListener;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.security.web.authentication.preauth.x509.SubjectX500PrincipalExtractor;
 import org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter;
+import org.springframework.security.web.authentication.preauth.x509.X509TestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -118,6 +122,26 @@ public class X509ConfigurerTests {
 		// @formatter:off
 		this.mvc.perform(get("/").with(x509(certificate)))
 				.andExpect(authenticated().withUsername("rod"));
+		// @formatter:on
+	}
+
+	@Test
+	public void x509WhenSubjectX500PrincipalExtractor() throws Exception {
+		this.spring.register(SubjectX500PrincipalExtractorConfig.class).autowire();
+		X509Certificate certificate = loadCert("rod.cer");
+		// @formatter:off
+		this.mvc.perform(get("/").with(x509(certificate)))
+				.andExpect(authenticated().withUsername("rod"));
+		// @formatter:on
+	}
+
+	@Test
+	public void x509WhenSubjectX500PrincipalExtractorBean() throws Exception {
+		this.spring.register(SubjectX500PrincipalExtractorEmailConfig.class).autowire();
+		X509Certificate certificate = X509TestUtils.buildTestCertificate();
+		// @formatter:off
+		this.mvc.perform(get("/").with(x509(certificate)))
+				.andExpect(authenticated().withUsername("luke@monkeymachine"));
 		// @formatter:on
 	}
 
@@ -248,6 +272,62 @@ public class X509ConfigurerTests {
 				.inMemoryAuthentication()
 					.withUser("rod").password("password").roles("USER", "ADMIN");
 			// @formatter:on
+		}
+
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	static class SubjectX500PrincipalExtractorConfig {
+
+		@Bean
+		SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+			// @formatter:off
+			http
+					.x509((x509) -> x509
+							.x509PrincipalExtractor(new SubjectX500PrincipalExtractor())
+					);
+			// @formatter:on
+			return http.build();
+		}
+
+		@Bean
+		UserDetailsService userDetailsService() {
+			UserDetails user = User.withDefaultPasswordEncoder()
+				.username("rod")
+				.password("password")
+				.roles("USER", "ADMIN")
+				.build();
+			return new InMemoryUserDetailsManager(user);
+		}
+
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	static class SubjectX500PrincipalExtractorEmailConfig {
+
+		@Bean
+		SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+			SubjectX500PrincipalExtractor principalExtractor = new SubjectX500PrincipalExtractor();
+			principalExtractor.setExtractPrincipalNameFromEmail(true);
+			// @formatter:off
+			http
+				.x509((x509) -> x509
+					.x509PrincipalExtractor(principalExtractor)
+				);
+			// @formatter:on
+			return http.build();
+		}
+
+		@Bean
+		UserDetailsService userDetailsService() {
+			UserDetails user = User.withDefaultPasswordEncoder()
+				.username("luke@monkeymachine")
+				.password("password")
+				.roles("USER", "ADMIN")
+				.build();
+			return new InMemoryUserDetailsManager(user);
 		}
 
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 springBootVersion=2.7.12
-version=5.8.16-rxlogix-2
+version=5.8.16-rxlogix-3
 samplesBranch=5.8.x
 org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2Utils.java
@@ -18,6 +18,7 @@ package org.springframework.security.saml2.provider.service.authentication;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.zip.Deflater;
@@ -59,7 +60,7 @@ final class Saml2Utils {
 	static String samlInflate(byte[] b) {
 		try {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
-			InflaterOutputStream iout = new InflaterOutputStream(out, new Inflater(true));
+			InflaterOutputStream iout = new InflaterOutputStream(new CappedOutputStream(out), new Inflater(true));
 			iout.write(b);
 			iout.finish();
 			return new String(out.toByteArray(), StandardCharsets.UTF_8);
@@ -67,6 +68,29 @@ final class Saml2Utils {
 		catch (IOException ex) {
 			throw new Saml2Exception("Unable to inflate string", ex);
 		}
+	}
+
+	static class CappedOutputStream extends OutputStream {
+
+		private static final long MAX_SIZE = 1024 * 1024;
+
+		private final OutputStream delegate;
+
+		private int size;
+
+		CappedOutputStream(OutputStream delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+			if (this.size >= MAX_SIZE) {
+				throw new IOException("SAML payload exceeded maximum size of " + MAX_SIZE);
+			}
+			this.delegate.write(b);
+			this.size++;
+		}
+
 	}
 
 }

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutRequestValidator.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutRequestValidator.java
@@ -18,8 +18,9 @@ package org.springframework.security.saml2.provider.service.authentication.logou
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.function.Consumer;
+import java.util.Collections;
 
 import net.shibboleth.utilities.java.support.xml.ParserPool;
 import org.opensaml.core.config.ConfigurationService;
@@ -79,10 +80,13 @@ public final class OpenSamlLogoutRequestValidator implements Saml2LogoutRequestV
 		Authentication authentication = parameters.getAuthentication();
 		byte[] b = Saml2Utils.samlDecode(request.getSamlRequest());
 		LogoutRequest logoutRequest = parse(inflateIfRequired(request, b));
-		return Saml2LogoutValidatorResult.withErrors()
-			.errors(verifySignature(request, logoutRequest, registration))
-			.errors(validateRequest(logoutRequest, registration, authentication))
-			.build();
+		Collection<Saml2Error> errors = verifySignature(request, logoutRequest, registration);
+		if (!errors.isEmpty()) {
+			return Saml2LogoutValidatorResult.withErrors(errors.toArray(new Saml2Error[0])).build();
+		}
+		errors = validateRequest(logoutRequest, registration, authentication);
+		return errors.isEmpty() ? Saml2LogoutValidatorResult.success()
+				: Saml2LogoutValidatorResult.withErrors(errors.toArray(new Saml2Error[0])).build();
 	}
 
 	private String inflateIfRequired(Saml2LogoutRequest request, byte[] b) {
@@ -104,74 +108,61 @@ public final class OpenSamlLogoutRequestValidator implements Saml2LogoutRequestV
 		}
 	}
 
-	private Consumer<Collection<Saml2Error>> verifySignature(Saml2LogoutRequest request, LogoutRequest logoutRequest,
+	private Collection<Saml2Error> verifySignature(Saml2LogoutRequest request, LogoutRequest logoutRequest,
 			RelyingPartyRegistration registration) {
-		return (errors) -> {
-			VerifierPartial partial = OpenSamlVerificationUtils.verifySignature(logoutRequest, registration);
-			if (logoutRequest.isSigned()) {
-				errors.addAll(partial.post(logoutRequest.getSignature()));
-			}
-			else {
-				errors.addAll(partial.redirect(request));
-			}
-		};
+		VerifierPartial partial = OpenSamlVerificationUtils.verifySignature(logoutRequest, registration);
+		if (logoutRequest.isSigned()) {
+			return partial.post(logoutRequest.getSignature());
+		}
+		return partial.redirect(request);
 	}
 
-	private Consumer<Collection<Saml2Error>> validateRequest(LogoutRequest request,
-			RelyingPartyRegistration registration, Authentication authentication) {
-		return (errors) -> {
-			validateIssuer(request, registration).accept(errors);
-			validateDestination(request, registration).accept(errors);
-			validateSubject(request, registration, authentication).accept(errors);
-		};
+	private Collection<Saml2Error> validateRequest(LogoutRequest request, RelyingPartyRegistration registration,
+			Authentication authentication) {
+		Collection<Saml2Error> errors = new ArrayList<>();
+		errors.addAll(validateIssuer(request, registration));
+		errors.addAll(validateDestination(request, registration));
+		errors.addAll(validateSubject(request, registration, authentication));
+		return errors;
 	}
 
-	private Consumer<Collection<Saml2Error>> validateIssuer(LogoutRequest request,
-			RelyingPartyRegistration registration) {
-		return (errors) -> {
-			if (request.getIssuer() == null) {
-				errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to find issuer in LogoutRequest"));
-				return;
-			}
-			String issuer = request.getIssuer().getValue();
-			if (!issuer.equals(registration.getAssertingPartyDetails().getEntityId())) {
-				errors
-					.add(new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to match issuer to configured issuer"));
-			}
-		};
+	private Collection<Saml2Error> validateIssuer(LogoutRequest request, RelyingPartyRegistration registration) {
+		if (request.getIssuer() == null) {
+			return Collections.singletonList(
+					new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to find issuer in LogoutRequest"));
+		}
+		String issuer = request.getIssuer().getValue();
+		if (!issuer.equals(registration.getAssertingPartyDetails().getEntityId())) {
+			return Collections.singletonList(
+					new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to match issuer to configured issuer"));
+		}
+		return Collections.emptyList();
 	}
 
-	private Consumer<Collection<Saml2Error>> validateDestination(LogoutRequest request,
-			RelyingPartyRegistration registration) {
-		return (errors) -> {
-			if (request.getDestination() == null) {
-				errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION,
-						"Failed to find destination in LogoutRequest"));
-				return;
-			}
-			String destination = request.getDestination();
-			if (!destination.equals(registration.getSingleLogoutServiceLocation())) {
-				errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION,
-						"Failed to match destination to configured destination"));
-			}
-		};
+	private Collection<Saml2Error> validateDestination(LogoutRequest request, RelyingPartyRegistration registration) {
+		if (request.getDestination() == null) {
+			return Collections.singletonList(
+					new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION, "Failed to find destination in LogoutRequest"));
+		}
+		String destination = request.getDestination();
+		if (!destination.equals(registration.getSingleLogoutServiceLocation())) {
+			return Collections.singletonList(new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION,
+					"Failed to match destination to configured destination"));
+		}
+		return Collections.emptyList();
 	}
 
-	private Consumer<Collection<Saml2Error>> validateSubject(LogoutRequest request,
-			RelyingPartyRegistration registration, Authentication authentication) {
-		return (errors) -> {
-			if (authentication == null) {
-				return;
-			}
-			NameID nameId = getNameId(request, registration);
-			if (nameId == null) {
-				errors
-					.add(new Saml2Error(Saml2ErrorCodes.SUBJECT_NOT_FOUND, "Failed to find subject in LogoutRequest"));
-				return;
-			}
-
-			validateNameId(nameId, authentication, errors);
-		};
+	private Collection<Saml2Error> validateSubject(LogoutRequest request, RelyingPartyRegistration registration,
+			Authentication authentication) {
+		if (authentication == null) {
+			return Collections.emptyList();
+		}
+		NameID nameId = getNameId(request, registration);
+		if (nameId == null) {
+			return Collections.singletonList(
+					new Saml2Error(Saml2ErrorCodes.SUBJECT_NOT_FOUND, "Failed to find subject in LogoutRequest"));
+		}
+		return validateNameId(nameId, authentication);
 	}
 
 	private NameID getNameId(LogoutRequest request, RelyingPartyRegistration registration) {
@@ -186,12 +177,13 @@ public final class OpenSamlLogoutRequestValidator implements Saml2LogoutRequestV
 		return decryptNameId(encryptedId, registration);
 	}
 
-	private void validateNameId(NameID nameId, Authentication authentication, Collection<Saml2Error> errors) {
+	private Collection<Saml2Error> validateNameId(NameID nameId, Authentication authentication) {
 		String name = nameId.getValue();
 		if (!name.equals(authentication.getName())) {
-			errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_REQUEST,
+			return Collections.singletonList(new Saml2Error(Saml2ErrorCodes.INVALID_REQUEST,
 					"Failed to match subject in LogoutRequest with currently logged in user"));
 		}
+		return Collections.emptyList();
 	}
 
 	private NameID decryptNameId(EncryptedID encryptedId, RelyingPartyRegistration registration) {

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutResponseValidator.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutResponseValidator.java
@@ -18,8 +18,9 @@ package org.springframework.security.saml2.provider.service.authentication.logou
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.function.Consumer;
+import java.util.Collections;
 
 import net.shibboleth.utilities.java.support.xml.ParserPool;
 import org.opensaml.core.config.ConfigurationService;
@@ -76,11 +77,13 @@ public class OpenSamlLogoutResponseValidator implements Saml2LogoutResponseValid
 		RelyingPartyRegistration registration = parameters.getRelyingPartyRegistration();
 		byte[] b = Saml2Utils.samlDecode(response.getSamlResponse());
 		LogoutResponse logoutResponse = parse(inflateIfRequired(response, b));
-		return Saml2LogoutValidatorResult.withErrors()
-			.errors(verifySignature(response, logoutResponse, registration))
-			.errors(validateRequest(logoutResponse, registration))
-			.errors(validateLogoutRequest(logoutResponse, request.getId()))
-			.build();
+		Collection<Saml2Error> errors = verifySignature(response, logoutResponse, registration);
+		if (!errors.isEmpty()) {
+			return Saml2LogoutValidatorResult.withErrors(errors.toArray(new Saml2Error[0])).build();
+		}
+		errors = validateRequest(logoutResponse, registration, request.getId());
+		return errors.isEmpty() ? Saml2LogoutValidatorResult.success()
+				: Saml2LogoutValidatorResult.withErrors(errors.toArray(new Saml2Error[0])).build();
 	}
 
 	private String inflateIfRequired(Saml2LogoutResponse response, byte[] b) {
@@ -102,88 +105,77 @@ public class OpenSamlLogoutResponseValidator implements Saml2LogoutResponseValid
 		}
 	}
 
-	private Consumer<Collection<Saml2Error>> verifySignature(Saml2LogoutResponse response,
-			LogoutResponse logoutResponse, RelyingPartyRegistration registration) {
-		return (errors) -> {
-			VerifierPartial partial = OpenSamlVerificationUtils.verifySignature(logoutResponse, registration);
-			if (logoutResponse.isSigned()) {
-				errors.addAll(partial.post(logoutResponse.getSignature()));
-			}
-			else {
-				errors.addAll(partial.redirect(response));
-			}
-		};
-	}
-
-	private Consumer<Collection<Saml2Error>> validateRequest(LogoutResponse response,
+	private Collection<Saml2Error> verifySignature(Saml2LogoutResponse response, LogoutResponse logoutResponse,
 			RelyingPartyRegistration registration) {
-		return (errors) -> {
-			validateIssuer(response, registration).accept(errors);
-			validateDestination(response, registration).accept(errors);
-			validateStatus(response).accept(errors);
-		};
+		VerifierPartial partial = OpenSamlVerificationUtils.verifySignature(logoutResponse, registration);
+		if (logoutResponse.isSigned()) {
+			return partial.post(logoutResponse.getSignature());
+		}
+		return partial.redirect(response);
 	}
 
-	private Consumer<Collection<Saml2Error>> validateIssuer(LogoutResponse response,
-			RelyingPartyRegistration registration) {
-		return (errors) -> {
-			if (response.getIssuer() == null) {
-				errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to find issuer in LogoutResponse"));
-				return;
-			}
-			String issuer = response.getIssuer().getValue();
-			if (!issuer.equals(registration.getAssertingPartyDetails().getEntityId())) {
-				errors
-					.add(new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to match issuer to configured issuer"));
-			}
-		};
+	private Collection<Saml2Error> validateRequest(LogoutResponse response, RelyingPartyRegistration registration,
+			String logoutRequestId) {
+		Collection<Saml2Error> errors = new ArrayList<>();
+		errors.addAll(validateIssuer(response, registration));
+		errors.addAll(validateDestination(response, registration));
+		errors.addAll(validateStatus(response));
+		errors.addAll(validateLogoutRequest(response, logoutRequestId));
+		return errors;
 	}
 
-	private Consumer<Collection<Saml2Error>> validateDestination(LogoutResponse response,
-			RelyingPartyRegistration registration) {
-		return (errors) -> {
-			if (response.getDestination() == null) {
-				errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION,
-						"Failed to find destination in LogoutResponse"));
-				return;
-			}
-			String destination = response.getDestination();
-			if (!destination.equals(registration.getSingleLogoutServiceResponseLocation())) {
-				errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION,
-						"Failed to match destination to configured destination"));
-			}
-		};
+	private Collection<Saml2Error> validateIssuer(LogoutResponse response, RelyingPartyRegistration registration) {
+		if (response.getIssuer() == null) {
+			return Collections.singletonList(
+					new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to find issuer in LogoutResponse"));
+		}
+		String issuer = response.getIssuer().getValue();
+		if (!issuer.equals(registration.getAssertingPartyDetails().getEntityId())) {
+			return Collections.singletonList(
+					new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to match issuer to configured issuer"));
+		}
+		return Collections.emptyList();
 	}
 
-	private Consumer<Collection<Saml2Error>> validateStatus(LogoutResponse response) {
-		return (errors) -> {
-			if (response.getStatus() == null) {
-				return;
-			}
-			if (response.getStatus().getStatusCode() == null) {
-				return;
-			}
-			if (StatusCode.SUCCESS.equals(response.getStatus().getStatusCode().getValue())) {
-				return;
-			}
-			if (StatusCode.PARTIAL_LOGOUT.equals(response.getStatus().getStatusCode().getValue())) {
-				return;
-			}
-			errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_RESPONSE, "Response indicated logout failed"));
-		};
+	private Collection<Saml2Error> validateDestination(LogoutResponse response, RelyingPartyRegistration registration) {
+		if (response.getDestination() == null) {
+			return Collections.singletonList(new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION,
+					"Failed to find destination in LogoutResponse"));
+		}
+		String destination = response.getDestination();
+		if (!destination.equals(registration.getSingleLogoutServiceResponseLocation())) {
+			return Collections.singletonList(new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION,
+					"Failed to match destination to configured destination"));
+		}
+		return Collections.emptyList();
 	}
 
-	private Consumer<Collection<Saml2Error>> validateLogoutRequest(LogoutResponse response, String id) {
-		return (errors) -> {
-			if (response.getInResponseTo() == null) {
-				return;
-			}
-			if (response.getInResponseTo().equals(id)) {
-				return;
-			}
-			errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_RESPONSE,
-					"LogoutResponse InResponseTo doesn't match ID of associated LogoutRequest"));
-		};
+	private Collection<Saml2Error> validateStatus(LogoutResponse response) {
+		if (response.getStatus() == null) {
+			return Collections.emptyList();
+		}
+		if (response.getStatus().getStatusCode() == null) {
+			return Collections.emptyList();
+		}
+		if (StatusCode.SUCCESS.equals(response.getStatus().getStatusCode().getValue())) {
+			return Collections.emptyList();
+		}
+		if (StatusCode.PARTIAL_LOGOUT.equals(response.getStatus().getStatusCode().getValue())) {
+			return Collections.emptyList();
+		}
+		return Collections
+			.singletonList(new Saml2Error(Saml2ErrorCodes.INVALID_RESPONSE, "Response indicated logout failed"));
+	}
+
+	private Collection<Saml2Error> validateLogoutRequest(LogoutResponse response, String id) {
+		if (response.getInResponseTo() == null) {
+			return Collections.emptyList();
+		}
+		if (response.getInResponseTo().equals(id)) {
+			return Collections.emptyList();
+		}
+		return Collections.singletonList(new Saml2Error(Saml2ErrorCodes.INVALID_RESPONSE,
+				"LogoutResponse InResponseTo doesn't match ID of associated LogoutRequest"));
 	}
 
 }

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/Saml2Utils.java
@@ -18,6 +18,7 @@ package org.springframework.security.saml2.provider.service.authentication.logou
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.zip.Deflater;
@@ -63,7 +64,7 @@ final class Saml2Utils {
 	static String samlInflate(byte[] b) {
 		try {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
-			InflaterOutputStream iout = new InflaterOutputStream(out, new Inflater(true));
+			InflaterOutputStream iout = new InflaterOutputStream(new CappedOutputStream(out), new Inflater(true));
 			iout.write(b);
 			iout.finish();
 			return new String(out.toByteArray(), StandardCharsets.UTF_8);
@@ -71,6 +72,29 @@ final class Saml2Utils {
 		catch (IOException ex) {
 			throw new Saml2Exception("Unable to inflate string", ex);
 		}
+	}
+
+	static class CappedOutputStream extends OutputStream {
+
+		private static final long MAX_SIZE = 1024 * 1024;
+
+		private final OutputStream delegate;
+
+		private int size;
+
+		CappedOutputStream(OutputStream delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+			if (this.size >= MAX_SIZE) {
+				throw new IOException("SAML payload exceeded maximum size of " + MAX_SIZE);
+			}
+			this.delegate.write(b);
+			this.size++;
+		}
+
 	}
 
 }

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/Saml2WebSsoAuthenticationRequestFilter.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/Saml2WebSsoAuthenticationRequestFilter.java
@@ -244,7 +244,7 @@ public class Saml2WebSsoAuthenticationRequestFilter extends OncePerRequestFilter
 		html.append("        </noscript>\n");
 		html.append("        \n");
 		html.append("        <form action=\"");
-		html.append(authenticationRequestUri);
+		html.append(HtmlUtils.htmlEscape(authenticationRequestUri));
 		html.append("\" method=\"post\">\n");
 		html.append("            <div>\n");
 		html.append("                <input type=\"hidden\" name=\"SAMLRequest\" value=\"");

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/Saml2Utils.java
@@ -18,6 +18,7 @@ package org.springframework.security.saml2.provider.service.web.authentication;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.zip.Deflater;
@@ -63,7 +64,7 @@ final class Saml2Utils {
 	static String samlInflate(byte[] b) {
 		try {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
-			InflaterOutputStream iout = new InflaterOutputStream(out, new Inflater(true));
+			InflaterOutputStream iout = new InflaterOutputStream(new CappedOutputStream(out), new Inflater(true));
 			iout.write(b);
 			iout.finish();
 			return new String(out.toByteArray(), StandardCharsets.UTF_8);
@@ -71,6 +72,29 @@ final class Saml2Utils {
 		catch (IOException ex) {
 			throw new Saml2Exception("Unable to inflate string", ex);
 		}
+	}
+
+	static class CappedOutputStream extends OutputStream {
+
+		private static final long MAX_SIZE = 1024 * 1024;
+
+		private final OutputStream delegate;
+
+		private int size;
+
+		CappedOutputStream(OutputStream delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+			if (this.size >= MAX_SIZE) {
+				throw new IOException("SAML payload exceeded maximum size of " + MAX_SIZE);
+			}
+			this.delegate.write(b);
+			this.size++;
+		}
+
 	}
 
 }

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutRequestFilter.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutRequestFilter.java
@@ -231,7 +231,7 @@ public final class Saml2LogoutRequestFilter extends OncePerRequestFilter {
 		html.append("        </noscript>\n");
 		html.append("        \n");
 		html.append("        <form action=\"");
-		html.append(location);
+		html.append(HtmlUtils.htmlEscape(location));
 		html.append("\" method=\"post\">\n");
 		html.append("            <div>\n");
 		html.append("                <input type=\"hidden\" name=\"SAMLResponse\" value=\"");

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2RelyingPartyInitiatedLogoutSuccessHandler.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2RelyingPartyInitiatedLogoutSuccessHandler.java
@@ -132,7 +132,7 @@ public final class Saml2RelyingPartyInitiatedLogoutSuccessHandler implements Log
 		html.append("        </noscript>\n");
 		html.append("        \n");
 		html.append("        <form action=\"");
-		html.append(location);
+		html.append(HtmlUtils.htmlEscape(location));
 		html.append("\" method=\"post\">\n");
 		html.append("            <div>\n");
 		html.append("                <input type=\"hidden\" name=\"SAMLRequest\" value=\"");

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2Utils.java
@@ -18,6 +18,7 @@ package org.springframework.security.saml2.provider.service.web.authentication.l
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.zip.Deflater;
@@ -63,7 +64,7 @@ final class Saml2Utils {
 	static String samlInflate(byte[] b) {
 		try {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
-			InflaterOutputStream iout = new InflaterOutputStream(out, new Inflater(true));
+			InflaterOutputStream iout = new InflaterOutputStream(new CappedOutputStream(out), new Inflater(true));
 			iout.write(b);
 			iout.finish();
 			return new String(out.toByteArray(), StandardCharsets.UTF_8);
@@ -71,6 +72,29 @@ final class Saml2Utils {
 		catch (IOException ex) {
 			throw new Saml2Exception("Unable to inflate string", ex);
 		}
+	}
+
+	static class CappedOutputStream extends OutputStream {
+
+		private static final long MAX_SIZE = 1024 * 1024;
+
+		private final OutputStream delegate;
+
+		private int size;
+
+		CappedOutputStream(OutputStream delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+			if (this.size >= MAX_SIZE) {
+				throw new IOException("SAML payload exceeded maximum size of " + MAX_SIZE);
+			}
+			this.delegate.write(b);
+			this.size++;
+		}
+
 	}
 
 }

--- a/saml2/saml2-service-provider/src/opensaml3Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlAuthenticationProvider.java
+++ b/saml2/saml2-service-provider/src/opensaml3Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlAuthenticationProvider.java
@@ -479,6 +479,12 @@ public final class OpenSamlAuthenticationProvider implements AuthenticationProvi
 
 		ResponseToken responseToken = new ResponseToken(response, token);
 		Saml2ResponseValidatorResult result = this.responseSignatureValidator.convert(responseToken);
+		if (result.hasErrors()) {
+			// Do not decrypt before the response signature has been verified
+			// (CVE-2026-41694)
+			reportErrors(response, result.getErrors());
+			return;
+		}
 		if (responseSigned) {
 			this.responseElementsDecrypter.accept(responseToken);
 		}
@@ -486,8 +492,15 @@ public final class OpenSamlAuthenticationProvider implements AuthenticationProvi
 		boolean allAssertionsSigned = true;
 		for (Assertion assertion : response.getAssertions()) {
 			AssertionToken assertionToken = new AssertionToken(assertion, token);
-			result = result.concat(this.assertionSignatureValidator.convert(assertionToken));
+			Saml2ResponseValidatorResult assertionSignatureResult = this.assertionSignatureValidator
+				.convert(assertionToken);
+			result = result.concat(assertionSignatureResult);
 			allAssertionsSigned = allAssertionsSigned && assertion.isSigned();
+			if (assertionSignatureResult.hasErrors()) {
+				// Do not decrypt an assertion whose signature failed to verify
+				// (CVE-2026-41694)
+				continue;
+			}
 			if (responseSigned || assertion.isSigned()) {
 				this.assertionElementsDecrypter.accept(new AssertionToken(assertion, token));
 			}
@@ -505,24 +518,25 @@ public final class OpenSamlAuthenticationProvider implements AuthenticationProvi
 			result = result.concat(error);
 		}
 
-		if (result.hasErrors()) {
-			Collection<Saml2Error> errors = result.getErrors();
-			if (logger.isTraceEnabled()) {
-				logger.debug("Found " + errors.size() + " validation errors in SAML response [" + response.getID()
-						+ "]: " + errors);
-			}
-			else if (logger.isDebugEnabled()) {
-				logger
-					.debug("Found " + errors.size() + " validation errors in SAML response [" + response.getID() + "]");
-			}
-			Saml2Error first = errors.iterator().next();
-			throw createAuthenticationException(first.getErrorCode(), first.getDescription(), null);
-		}
-		else {
+		reportErrors(response, result.getErrors());
+	}
+
+	private void reportErrors(Response response, Collection<Saml2Error> errors) {
+		if (errors.isEmpty()) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Successfully processed SAML Response [" + response.getID() + "]");
 			}
+			return;
 		}
+		if (logger.isTraceEnabled()) {
+			logger.debug("Found " + errors.size() + " validation errors in SAML response [" + response.getID() + "]: "
+					+ errors);
+		}
+		else if (logger.isDebugEnabled()) {
+			logger.debug("Found " + errors.size() + " validation errors in SAML response [" + response.getID() + "]");
+		}
+		Saml2Error first = errors.iterator().next();
+		throw createAuthenticationException(first.getErrorCode(), first.getDescription(), null);
 	}
 
 	private Converter<ResponseToken, Saml2ResponseValidatorResult> createDefaultResponseSignatureValidator() {

--- a/saml2/saml2-service-provider/src/opensaml3Test/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlAuthenticationProviderTests.java
+++ b/saml2/saml2-service-provider/src/opensaml3Test/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlAuthenticationProviderTests.java
@@ -351,7 +351,7 @@ public class OpenSamlAuthenticationProviderTests {
 		response.getEncryptedAssertions().add(encryptedAssertion);
 		TestOpenSamlObjects.signed(response, TestSaml2X509Credentials.assertingPartySigningCredential(),
 				RELYING_PARTY_ENTITY_ID);
-		Saml2AuthenticationToken token = token(response, registration()
+		Saml2AuthenticationToken token = token(response, verifying(registration())
 			.decryptionX509Credentials((c) -> c.add(TestSaml2X509Credentials.assertingPartyPrivateCredential())));
 		assertThatExceptionOfType(Saml2AuthenticationException.class)
 			.isThrownBy(() -> this.provider.authenticate(token))

--- a/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
+++ b/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
@@ -543,55 +543,72 @@ public final class OpenSaml4AuthenticationProvider implements AuthenticationProv
 		boolean responseSigned = response.isSigned();
 
 		ResponseToken responseToken = new ResponseToken(response, token);
-		Saml2ResponseValidatorResult result = this.responseSignatureValidator.convert(responseToken);
+		Collection<Saml2Error> responseSignatureErrors = this.responseSignatureValidator.convert(responseToken)
+			.getErrors();
+		if (!responseSignatureErrors.isEmpty()) {
+			// Do not decrypt before the response signature has been verified
+			// (CVE-2026-41694)
+			reportErrors(response, responseSignatureErrors);
+			return;
+		}
+
+		Collection<Saml2Error> errors = new ArrayList<>();
 		if (responseSigned) {
 			this.responseElementsDecrypter.accept(responseToken);
 		}
 		else if (!response.getEncryptedAssertions().isEmpty()) {
-			result = result.concat(new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE,
+			errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE,
 					"Did not decrypt response [" + response.getID() + "] since it is not signed"));
 		}
-		result = result.concat(this.responseValidator.convert(responseToken));
+		errors.addAll(this.responseValidator.convert(responseToken).getErrors());
 		boolean allAssertionsSigned = true;
 		for (Assertion assertion : response.getAssertions()) {
 			AssertionToken assertionToken = new AssertionToken(assertion, token);
-			result = result.concat(this.assertionSignatureValidator.convert(assertionToken));
+			Collection<Saml2Error> assertionSignatureErrors = this.assertionSignatureValidator.convert(assertionToken)
+				.getErrors();
+			errors.addAll(assertionSignatureErrors);
 			allAssertionsSigned = allAssertionsSigned && assertion.isSigned();
+			if (!assertionSignatureErrors.isEmpty()) {
+				// Do not decrypt an assertion whose signature failed to verify
+				// (CVE-2026-41694)
+				continue;
+			}
 			if (responseSigned || assertion.isSigned()) {
 				this.assertionElementsDecrypter.accept(new AssertionToken(assertion, token));
 			}
-			result = result.concat(this.assertionValidator.convert(assertionToken));
+			errors.addAll(this.assertionValidator.convert(assertionToken).getErrors());
 		}
 		if (!responseSigned && !allAssertionsSigned) {
 			String description = "Either the response or one of the assertions is unsigned. "
 					+ "Please either sign the response or all of the assertions.";
-			result = result.concat(new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, description));
+			errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, description));
 		}
 		Assertion firstAssertion = CollectionUtils.firstElement(response.getAssertions());
 		if (firstAssertion != null && !hasName(firstAssertion)) {
-			Saml2Error error = new Saml2Error(Saml2ErrorCodes.SUBJECT_NOT_FOUND,
-					"Assertion [" + firstAssertion.getID() + "] is missing a subject");
-			result = result.concat(error);
+			errors.add(new Saml2Error(Saml2ErrorCodes.SUBJECT_NOT_FOUND,
+					"Assertion [" + firstAssertion.getID() + "] is missing a subject"));
 		}
 
-		if (result.hasErrors()) {
-			Collection<Saml2Error> errors = result.getErrors();
-			if (this.logger.isTraceEnabled()) {
-				this.logger.debug("Found " + errors.size() + " validation errors in SAML response [" + response.getID()
-						+ "]: " + errors);
-			}
-			else if (this.logger.isDebugEnabled()) {
-				this.logger
-					.debug("Found " + errors.size() + " validation errors in SAML response [" + response.getID() + "]");
-			}
-			Saml2Error first = errors.iterator().next();
-			throw createAuthenticationException(first.getErrorCode(), first.getDescription(), null);
-		}
-		else {
+		reportErrors(response, errors);
+	}
+
+	private void reportErrors(Response response, Collection<Saml2Error> errors) {
+		if (errors.isEmpty()) {
 			if (this.logger.isDebugEnabled()) {
 				this.logger.debug("Successfully processed SAML Response [" + response.getID() + "]");
 			}
+			return;
 		}
+		if (this.logger.isTraceEnabled()) {
+			this.logger.debug("Found " + errors.size() + " validation errors in SAML response [" + response.getID()
+					+ "]: " + errors);
+		}
+		else if (this.logger.isDebugEnabled()) {
+			this.logger
+				.debug("Found " + errors.size() + " validation errors in SAML response [" + response.getID() + "]");
+		}
+		Saml2Error first = errors.iterator().next();
+		throw createAuthenticationException(first.getErrorCode(), first.getDescription(), null);
 	}
 
 	private Converter<ResponseToken, Saml2ResponseValidatorResult> createDefaultResponseSignatureValidator() {

--- a/saml2/saml2-service-provider/src/opensaml4Test/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProviderTests.java
+++ b/saml2/saml2-service-provider/src/opensaml4Test/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProviderTests.java
@@ -35,6 +35,7 @@ import javax.xml.namespace.QName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.shibboleth.utilities.java.support.xml.SerializeSupport;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.Marshaller;
@@ -92,6 +93,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Tests for {@link OpenSaml4AuthenticationProvider}
@@ -127,6 +129,54 @@ public class OpenSaml4AuthenticationProviderTests {
 		assertThat(!this.provider.supports(Authentication.class))
 			.withFailMessage(OpenSaml4AuthenticationProvider.class + "should not support " + Authentication.class)
 			.isTrue();
+	}
+
+	// gh-... / CVE-2026-41694
+	@Test
+	public void authenticateWhenResponseSignatureInvalidThenSkipsResponseAndAssertionValidation() {
+		Response response = response();
+		response.setDestination(DESTINATION + "invalid");
+		Assertion assertion = assertion();
+		response.getAssertions().add(signed(assertion));
+		// Sign the response with a credential the verifier does not trust
+		TestOpenSamlObjects.signed(response, TestSaml2X509Credentials.relyingPartyDecryptingCredential(),
+				RELYING_PARTY_ENTITY_ID);
+		OpenSaml4AuthenticationProvider provider = new OpenSaml4AuthenticationProvider();
+		Converter<ResponseToken, Saml2ResponseValidatorResult> responseValidator = mock(Converter.class);
+		Converter<OpenSaml4AuthenticationProvider.AssertionToken, Saml2ResponseValidatorResult> assertionValidator = mock(
+				Converter.class);
+		provider.setResponseValidator(responseValidator);
+		provider.setAssertionValidator(assertionValidator);
+		Saml2AuthenticationToken token = token(response, verifying(registration()));
+		assertThatExceptionOfType(Saml2AuthenticationException.class).isThrownBy(() -> provider.authenticate(token))
+			.satisfies(errorOf(Saml2ErrorCodes.INVALID_SIGNATURE));
+		verifyNoInteractions(responseValidator, assertionValidator);
+	}
+
+	@Test
+	public void authenticateWhenAssertionSignatureInvalidThenSkipsThatAssertionValidationOnly() {
+		Response response = response();
+		Assertion bad = assertion();
+		bad.setID("bad-assertion");
+		TestOpenSamlObjects.signed(bad, TestSaml2X509Credentials.relyingPartyDecryptingCredential(),
+				RELYING_PARTY_ENTITY_ID);
+		response.getAssertions().add(bad);
+		Assertion good = assertion();
+		good.setID("good-assertion");
+		response.getAssertions().add(signed(good));
+		OpenSaml4AuthenticationProvider provider = new OpenSaml4AuthenticationProvider();
+		Converter<OpenSaml4AuthenticationProvider.AssertionToken, Saml2ResponseValidatorResult> assertionValidator = mock(
+				Converter.class);
+		given(assertionValidator.convert(any(OpenSaml4AuthenticationProvider.AssertionToken.class)))
+			.willReturn(Saml2ResponseValidatorResult.success());
+		provider.setAssertionValidator(assertionValidator);
+		Saml2AuthenticationToken token = token(signed(response), verifying(registration()));
+		assertThatExceptionOfType(Saml2AuthenticationException.class).isThrownBy(() -> provider.authenticate(token))
+			.satisfies(errorOf(Saml2ErrorCodes.INVALID_SIGNATURE));
+		ArgumentCaptor<OpenSaml4AuthenticationProvider.AssertionToken> captor = ArgumentCaptor
+			.forClass(OpenSaml4AuthenticationProvider.AssertionToken.class);
+		verify(assertionValidator).convert(captor.capture());
+		assertThat(captor.getValue().getAssertion().getID()).isEqualTo("good-assertion");
 	}
 
 	@Test
@@ -480,7 +530,7 @@ public class OpenSaml4AuthenticationProviderTests {
 		EncryptedAssertion encryptedAssertion = TestOpenSamlObjects.encrypted(assertion(),
 				TestSaml2X509Credentials.assertingPartyEncryptingCredential());
 		response.getEncryptedAssertions().add(encryptedAssertion);
-		Saml2AuthenticationToken token = token(signed(response), registration()
+		Saml2AuthenticationToken token = token(signed(response), verifying(registration())
 			.decryptionX509Credentials((c) -> c.add(TestSaml2X509Credentials.assertingPartyPrivateCredential())));
 		assertThatExceptionOfType(Saml2AuthenticationException.class)
 			.isThrownBy(() -> this.provider.authenticate(token))

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/Saml2UtilsTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/Saml2UtilsTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.authentication;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.security.saml2.Saml2Exception;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class Saml2UtilsTests {
+
+	@Test
+	void testSaml2InflateWhenLargePayloadThenErrors() {
+		byte[] b = new byte[1024 * 1024 + 1];
+		for (int i = 0; i < b.length; i++) {
+			b[i] = 56;
+		}
+		byte[] deflated = Saml2Utils.samlDeflate(new String(b, StandardCharsets.UTF_8));
+		assertThatExceptionOfType(Saml2Exception.class).isThrownBy(() -> Saml2Utils.samlInflate(deflated))
+			.withStackTraceContaining("SAML payload exceeded maximum size");
+	}
+
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutRequestValidatorTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutRequestValidatorTests.java
@@ -26,6 +26,7 @@ import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.LogoutRequest;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.security.saml2.core.Saml2Error;
 import org.springframework.security.saml2.core.Saml2ErrorCodes;
 import org.springframework.security.saml2.core.Saml2ParameterNames;
 import org.springframework.security.saml2.core.TestSaml2X509Credentials;
@@ -160,6 +161,38 @@ public class OpenSamlLogoutRequestValidatorTests {
 				registration, authentication(registration));
 		Saml2LogoutValidatorResult result = this.manager.validate(parameters);
 		assertThat(result.hasErrors()).isFalse();
+	}
+
+	@Test
+	public void handleWhenSignatureVerificationFailsThenDoesNotValidateRequestFurther() {
+		RelyingPartyRegistration registration = registration().build();
+		LogoutRequest logoutRequest = TestOpenSamlObjects.assertingPartyLogoutRequest(registration);
+		sign(logoutRequest, registration);
+		logoutRequest.getIssuer().setValue("https://other-asserting-party.example");
+		logoutRequest.setDestination("https://wrong-destination.example");
+		logoutRequest.getNameID().setValue("someone-else");
+		Saml2LogoutRequest request = post(logoutRequest, registration);
+		Saml2LogoutRequestValidatorParameters parameters = new Saml2LogoutRequestValidatorParameters(request,
+				registration, authentication(registration));
+		Saml2LogoutValidatorResult result = this.manager.validate(parameters);
+		assertThat(result.hasErrors()).isTrue();
+		assertThat(result.getErrors()).extracting(Saml2Error::getErrorCode)
+			.containsOnly(Saml2ErrorCodes.INVALID_SIGNATURE);
+	}
+
+	@Test
+	public void handleWhenDestinationAndNameIdInvalidThenCollectsAllApplicableRequestErrors() {
+		RelyingPartyRegistration registration = registration().build();
+		LogoutRequest logoutRequest = TestOpenSamlObjects.assertingPartyLogoutRequest(registration);
+		logoutRequest.setDestination("https://wrong-destination.example");
+		logoutRequest.getNameID().setValue("wrong-user");
+		sign(logoutRequest, registration);
+		Saml2LogoutRequest request = post(logoutRequest, registration);
+		Saml2LogoutRequestValidatorParameters parameters = new Saml2LogoutRequestValidatorParameters(request,
+				registration, authentication(registration));
+		Saml2LogoutValidatorResult result = this.manager.validate(parameters);
+		assertThat(result.getErrors()).extracting(Saml2Error::getErrorCode)
+			.containsExactly(Saml2ErrorCodes.INVALID_DESTINATION, Saml2ErrorCodes.INVALID_REQUEST);
 	}
 
 	private RelyingPartyRegistration.Builder registration() {

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutResponseValidatorTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutResponseValidatorTests.java
@@ -24,6 +24,7 @@ import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.LogoutResponse;
 import org.opensaml.saml.saml2.core.StatusCode;
 
+import org.springframework.security.saml2.core.Saml2Error;
 import org.springframework.security.saml2.core.Saml2ErrorCodes;
 import org.springframework.security.saml2.core.Saml2ParameterNames;
 import org.springframework.security.saml2.core.TestSaml2X509Credentials;
@@ -143,6 +144,46 @@ public class OpenSamlLogoutResponseValidatorTests {
 		Saml2LogoutResponseValidatorParameters parameters = new Saml2LogoutResponseValidatorParameters(response,
 				logoutRequest, registration);
 		this.manager.validate(parameters);
+	}
+
+	@Test
+	public void handleWhenSignatureVerificationFailsThenDoesNotValidateResponseFurther() {
+		RelyingPartyRegistration registration = registration().build();
+		Saml2LogoutRequest logoutRequest = Saml2LogoutRequest.withRelyingPartyRegistration(registration)
+			.id("id")
+			.build();
+		LogoutResponse logoutResponse = TestOpenSamlObjects.assertingPartyLogoutResponse(registration);
+		sign(logoutResponse, registration);
+		logoutResponse.setDestination("https://wrong-destination.example");
+		logoutResponse.getStatus().getStatusCode().setValue(StatusCode.UNKNOWN_PRINCIPAL);
+		logoutResponse.setInResponseTo("wrong-id");
+		Saml2LogoutResponse response = post(logoutResponse, registration);
+		Saml2LogoutResponseValidatorParameters parameters = new Saml2LogoutResponseValidatorParameters(response,
+				logoutRequest, registration);
+		Saml2LogoutValidatorResult result = this.manager.validate(parameters);
+		assertThat(result.hasErrors()).isTrue();
+		assertThat(result.getErrors()).extracting(Saml2Error::getErrorCode)
+			.containsOnly(Saml2ErrorCodes.INVALID_SIGNATURE);
+	}
+
+	@Test
+	public void handleWhenDestinationStatusAndInResponseToInvalidThenCollectsAllApplicableRequestErrors() {
+		RelyingPartyRegistration registration = registration().build();
+		Saml2LogoutRequest logoutRequest = Saml2LogoutRequest.withRelyingPartyRegistration(registration)
+			.id("id")
+			.build();
+		LogoutResponse logoutResponse = TestOpenSamlObjects.assertingPartyLogoutResponse(registration);
+		logoutResponse.setDestination("https://wrong-destination.example");
+		logoutResponse.getStatus().getStatusCode().setValue(StatusCode.UNKNOWN_PRINCIPAL);
+		logoutResponse.setInResponseTo("wrong-id");
+		sign(logoutResponse, registration);
+		Saml2LogoutResponse response = post(logoutResponse, registration);
+		Saml2LogoutResponseValidatorParameters parameters = new Saml2LogoutResponseValidatorParameters(response,
+				logoutRequest, registration);
+		Saml2LogoutValidatorResult result = this.manager.validate(parameters);
+		assertThat(result.getErrors()).extracting(Saml2Error::getErrorCode)
+			.containsExactly(Saml2ErrorCodes.INVALID_DESTINATION, Saml2ErrorCodes.INVALID_RESPONSE,
+					Saml2ErrorCodes.INVALID_RESPONSE);
 	}
 
 	private RelyingPartyRegistration.Builder registration() {

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/Saml2WebSsoAuthenticationRequestFilterTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/Saml2WebSsoAuthenticationRequestFilterTests.java
@@ -209,6 +209,29 @@ public class Saml2WebSsoAuthenticationRequestFilterTests {
 			.contains("value=\"" + relayStateEncoded + "\"");
 	}
 
+	// gh-16673 / CVE-2026-41003
+	@Test
+	public void doFilterWhenPostAuthenticationRequestUriContainsHtmlThenActionIsEscaped() throws Exception {
+		String maliciousUri = "https://sso-url.example.com/IDP/SSO\"><script>alert(1)</script>";
+		RelyingPartyRegistration registration = this.rpBuilder
+			.assertingPartyDetails((asserting) -> asserting.singleSignOnServiceBinding(Saml2MessageBinding.POST))
+			.build();
+		Saml2AuthenticationRequestContext context = authenticationRequestContext()
+			.relyingPartyRegistration(registration)
+			.build();
+		Saml2PostAuthenticationRequest request = Saml2PostAuthenticationRequest
+			.withAuthenticationRequestContext(context)
+			.samlRequest("request")
+			.authenticationRequestUri(maliciousUri)
+			.build();
+		given(this.resolver.resolve(any())).willReturn(context);
+		given(this.factory.createPostAuthenticationRequest(any())).willReturn(request);
+		this.filter.doFilterInternal(this.request, this.response, this.filterChain);
+		String content = this.response.getContentAsString();
+		assertThat(content).doesNotContain("<script>alert(1)");
+		assertThat(content).contains("&lt;script&gt;alert(1)&lt;/script&gt;");
+	}
+
 	@Test
 	public void doFilterWhenSetAuthenticationRequestFactoryThenUses() throws Exception {
 		Saml2AuthenticationRequestContext context = authenticationRequestContext().build();

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutRequestFilterTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutRequestFilterTests.java
@@ -126,6 +126,34 @@ public class Saml2LogoutRequestFilterTests {
 		verify(this.securityContextHolderStrategy).getContext();
 	}
 
+	// gh-16673 / CVE-2026-41003
+	@Test
+	public void doFilterWhenResponseLocationContainsHtmlThenActionIsEscaped() throws Exception {
+		String maliciousLocation = "https://ap.example.org/slo\"><script>alert(1)</script>";
+		RelyingPartyRegistration registration = TestRelyingPartyRegistrations.full()
+			.assertingPartyDetails((party) -> party.singleLogoutServiceBinding(Saml2MessageBinding.POST)
+				.singleLogoutServiceResponseLocation(maliciousLocation))
+			.build();
+		Authentication authentication = new TestingAuthenticationToken("user", "password");
+		given(this.securityContextHolderStrategy.getContext()).willReturn(new SecurityContextImpl(authentication));
+		this.logoutRequestProcessingFilter.setSecurityContextHolderStrategy(this.securityContextHolderStrategy);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/logout/saml2/slo");
+		request.setServletPath("/logout/saml2/slo");
+		request.setParameter(Saml2ParameterNames.SAML_REQUEST, "request");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		given(this.relyingPartyRegistrationResolver.resolve(any(), any())).willReturn(registration);
+		given(this.logoutRequestValidator.validate(any())).willReturn(Saml2LogoutValidatorResult.success());
+		Saml2LogoutResponse logoutResponse = Saml2LogoutResponse.withRelyingPartyRegistration(registration)
+			.samlResponse("response")
+			.build();
+		given(this.logoutResponseResolver.resolve(any(), any())).willReturn(logoutResponse);
+		this.logoutRequestProcessingFilter.doFilterInternal(request, response, new MockFilterChain());
+		String content = response.getContentAsString();
+		assertThat(content).doesNotContain("<script>alert(1)");
+		assertThat(content).contains("&lt;script&gt;alert(1)&lt;/script&gt;");
+	}
+
 	@Test
 	public void doFilterWhenRequestMismatchesThenNoLogout() throws Exception {
 		Authentication authentication = new TestingAuthenticationToken("user", "password");

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2RelyingPartyInitiatedLogoutSuccessHandlerTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2RelyingPartyInitiatedLogoutSuccessHandlerTests.java
@@ -105,6 +105,29 @@ public class Saml2RelyingPartyInitiatedLogoutSuccessHandlerTests {
 		assertThat(content).contains("<script>window.onload = function() { document.forms[0].submit(); }</script>");
 	}
 
+	// gh-16673 / CVE-2026-41003
+	@Test
+	public void onLogoutSuccessWhenLocationContainsHtmlThenActionIsEscaped() throws Exception {
+		String maliciousLocation = "https://ap.example.org/slo\"><script>alert(1)</script>";
+		RelyingPartyRegistration registration = TestRelyingPartyRegistrations.full()
+			.assertingPartyDetails((party) -> party.singleLogoutServiceBinding(Saml2MessageBinding.POST)
+				.singleLogoutServiceLocation(maliciousLocation))
+			.build();
+		Authentication authentication = authentication(registration);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		Saml2LogoutRequest logoutRequest = Saml2LogoutRequest.withRelyingPartyRegistration(registration)
+			.samlRequest("request")
+			.build();
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/saml2/logout");
+		request.setServletPath("/saml2/logout");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		given(this.logoutRequestResolver.resolve(any(), any())).willReturn(logoutRequest);
+		this.logoutRequestSuccessHandler.onLogoutSuccess(request, response, authentication);
+		String content = response.getContentAsString();
+		assertThat(content).doesNotContain("<script>alert(1)");
+		assertThat(content).contains("&lt;script&gt;alert(1)&lt;/script&gt;");
+	}
+
 	private Saml2Authentication authentication(RelyingPartyRegistration registration) {
 		DefaultSaml2AuthenticatedPrincipal principal = new DefaultSaml2AuthenticatedPrincipal("user", new HashMap<>());
 		principal.setRelyingPartyRegistrationId(registration.getRegistrationId());

--- a/web/src/main/java/org/springframework/security/web/authentication/preauth/x509/SubjectDnX509PrincipalExtractor.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/preauth/x509/SubjectDnX509PrincipalExtractor.java
@@ -43,7 +43,9 @@ import org.springframework.util.Assert;
  * "EMAILADDRESS=jimi@hendrix.org, CN=..." giving a user name "jimi@hendrix.org"
  *
  * @author Luke Taylor
+ * @deprecated Please use {@link SubjectX500PrincipalExtractor} instead
  */
+@Deprecated
 public class SubjectDnX509PrincipalExtractor implements X509PrincipalExtractor, MessageSourceAware {
 
 	protected final Log logger = LogFactory.getLog(getClass());

--- a/web/src/main/java/org/springframework/security/web/authentication/preauth/x509/SubjectX500PrincipalExtractor.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/preauth/x509/SubjectX500PrincipalExtractor.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2004-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.preauth.x509;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.security.auth.x500.X500Principal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceAware;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.core.log.LogMessage;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.util.Assert;
+
+/**
+ * Extracts the principal from the {@link X500Principal#getName(String)} returned by
+ * {@link X509Certificate#getSubjectX500Principal()} passed into
+ * {@link #extractPrincipal(X509Certificate)} depending on the value of
+ * {@link #setExtractPrincipalNameFromEmail(boolean)}.
+ *
+ * @author Max Batischev
+ * @author Rob Winch
+ * @since 5.8.16
+ */
+public final class SubjectX500PrincipalExtractor implements X509PrincipalExtractor, MessageSourceAware {
+
+	private final Log logger = LogFactory.getLog(getClass());
+
+	private static final String EMAIL_SUBJECT_DN_TYPE = "OID.1.2.840.113549.1.9.1";
+
+	private static final String CN_SUBJECT_DN_TYPE = "CN";
+
+	private MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+
+	private String subjectDnType = CN_SUBJECT_DN_TYPE;
+
+	private String x500PrincipalFormat = X500Principal.RFC2253;
+
+	@Override
+	public Object extractPrincipal(X509Certificate clientCert) {
+		Assert.notNull(clientCert, "clientCert cannot be null");
+		X500Principal principal = clientCert.getSubjectX500Principal();
+		String subjectDN = principal.getName(this.x500PrincipalFormat);
+		this.logger.debug(LogMessage.format("Subject DN is '%s'", subjectDN));
+		String principalName = getSubject(subjectDN);
+		this.logger.debug(LogMessage.format("Extracted Principal name is '%s'", principalName));
+		return principalName;
+	}
+
+	private List<Rdn> getDns(String subjectDn) {
+		try {
+			// read most-specific first, see gh-19254
+			List<Rdn> rdns = new ArrayList<>(new LdapName(subjectDn).getRdns());
+			Collections.reverse(rdns);
+			return rdns;
+		}
+		catch (InvalidNameException ex) {
+			throw new BadCredentialsException("Failed to parse client certificate", ex);
+		}
+	}
+
+	private String getSubject(String subjectDn) {
+		for (Rdn rdn : getDns(subjectDn)) {
+			String type = rdn.getType();
+			if (this.subjectDnType.equals(type)) {
+				return String.valueOf(rdn.getValue());
+			}
+		}
+		throw new BadCredentialsException(this.messages.getMessage("SubjectX500PrincipalExtractor.noMatching",
+				new Object[] { subjectDn }, "No matching pattern was found in subject DN: {0}"));
+	}
+
+	@Override
+	public void setMessageSource(MessageSource messageSource) {
+		Assert.notNull(messageSource, "messageSource cannot be null");
+		this.messages = new MessageSourceAccessor(messageSource);
+	}
+
+	/**
+	 * Sets if the principal name should be extracted from the emailAddress or CN
+	 * attribute (default).
+	 *
+	 * By default, the format {@link X500Principal#RFC2253} is passed to
+	 * {@link X500Principal#getName(String)} and the principal is extracted from the CN
+	 * attribute as defined in
+	 * <a href="https://datatracker.ietf.org/doc/html/rfc2253#section-2.3">Converting
+	 * AttributeTypeAndValue of RFC2253</a>.
+	 *
+	 * If {@link #setExtractPrincipalNameFromEmail(boolean)} is {@code true}, then the
+	 * format {@link X500Principal#RFC2253} is passed to
+	 * {@link X500Principal#getName(String)} and the principal is extracted from the
+	 * <a href="https://oid-base.com/get/1.2.840.113549.1.9.1">OID.1.2.840.113549.1.9.1
+	 * (emailAddress)</a> attribute as defined in
+	 * <a href="https://datatracker.ietf.org/doc/html/rfc1779#section-2.3">Section 2.3 of
+	 * RFC1779</a>.
+	 * @param extractPrincipalNameFromEmail whether to extract the principal from the
+	 * emailAddress (default false)
+	 * @see <a href="https://datatracker.ietf.org/doc/html/rfc2253">RFC2253</a>
+	 * @see <a href="https://datatracker.ietf.org/doc/html/rfC1779">RFC1779</a>
+	 */
+	public void setExtractPrincipalNameFromEmail(boolean extractPrincipalNameFromEmail) {
+		if (extractPrincipalNameFromEmail) {
+			this.subjectDnType = EMAIL_SUBJECT_DN_TYPE;
+			this.x500PrincipalFormat = X500Principal.RFC1779;
+		}
+		else {
+			this.subjectDnType = CN_SUBJECT_DN_TYPE;
+			this.x500PrincipalFormat = X500Principal.RFC2253;
+		}
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/preauth/x509/X509AuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/preauth/x509/X509AuthenticationFilter.java
@@ -28,7 +28,7 @@ import org.springframework.security.web.authentication.preauth.AbstractPreAuthen
  */
 public class X509AuthenticationFilter extends AbstractPreAuthenticatedProcessingFilter {
 
-	private X509PrincipalExtractor principalExtractor = new SubjectDnX509PrincipalExtractor();
+	private X509PrincipalExtractor principalExtractor = new SubjectX500PrincipalExtractor();
 
 	@Override
 	protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {

--- a/web/src/main/java/org/springframework/security/web/savedrequest/CookieRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/CookieRequestCache.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.web.savedrequest;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 
@@ -58,7 +59,7 @@ public class CookieRequestCache implements RequestCache {
 			this.logger.debug("Request not saved as configured RequestMatcher did not match");
 			return;
 		}
-		String redirectUrl = UrlUtils.buildFullRequestUrl(request);
+		String redirectUrl = buildRelativeRequestUrl(request);
 		Cookie savedCookie = new Cookie(COOKIE_NAME, encodeCookie(redirectUrl));
 		savedCookie.setMaxAge(COOKIE_MAX_AGE);
 		savedCookie.setSecure(request.isSecure());
@@ -78,27 +79,25 @@ public class CookieRequestCache implements RequestCache {
 			return null;
 		}
 		UriComponents uriComponents = UriComponentsBuilder.fromUriString(originalURI).build();
+		if (!isRelativePath(originalURI)) {
+			this.logger.debug("Did not use saved request since cookie did not contain a relative path");
+			return null;
+		}
 		DefaultSavedRequest.Builder builder = new DefaultSavedRequest.Builder();
-		int port = getPort(uriComponents);
-		return builder.setScheme(uriComponents.getScheme())
-			.setServerName(uriComponents.getHost())
+		int port = request.getServerPort();
+		return builder.setScheme(request.getScheme())
+			.setServerName(request.getServerName())
 			.setRequestURI(uriComponents.getPath())
 			.setQueryString(uriComponents.getQuery())
 			.setServerPort(port)
 			.setMethod(request.getMethod())
 			.setLocales(Collections.list(request.getLocales()))
+			.setParameters(request.getParameterMap())
 			.build();
 	}
 
-	private int getPort(UriComponents uriComponents) {
-		int port = uriComponents.getPort();
-		if (port != -1) {
-			return port;
-		}
-		if ("https".equalsIgnoreCase(uriComponents.getScheme())) {
-			return 443;
-		}
-		return 80;
+	private boolean isRelativePath(String uri) {
+		return uri.startsWith("/") && !uri.startsWith("//");
 	}
 
 	@Override
@@ -122,13 +121,19 @@ public class CookieRequestCache implements RequestCache {
 		response.addCookie(removeSavedRequestCookie);
 	}
 
+	private static String buildRelativeRequestUrl(HttpServletRequest request) {
+		String uri = request.getRequestURI();
+		String query = request.getQueryString();
+		return (query != null) ? uri + "?" + query : uri;
+	}
+
 	private static String encodeCookie(String cookieValue) {
-		return Base64.getEncoder().encodeToString(cookieValue.getBytes());
+		return Base64.getEncoder().encodeToString(cookieValue.getBytes(StandardCharsets.UTF_8));
 	}
 
 	private String decodeCookie(String encodedCookieValue) {
 		try {
-			return new String(Base64.getDecoder().decode(encodedCookieValue.getBytes()));
+			return new String(Base64.getDecoder().decode(encodedCookieValue.getBytes(StandardCharsets.UTF_8)));
 		}
 		catch (IllegalArgumentException ex) {
 			this.logger.debug("Failed decode cookie value " + encodedCookieValue);

--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCache.java
@@ -17,6 +17,7 @@
 package org.springframework.security.web.server.savedrequest;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Collections;
@@ -90,8 +91,13 @@ public class CookieServerRequestCache implements ServerRequestCache {
 		return Mono.justOrEmpty(cookieMap.getFirst(REDIRECT_URI_COOKIE_NAME))
 			.map(HttpCookie::getValue)
 			.map(CookieServerRequestCache::decodeCookie)
-			.onErrorResume(IllegalArgumentException.class, (ex) -> Mono.empty())
-			.map(URI::create);
+			.flatMap((decoded) -> isRelativePath(decoded) ? Mono.just(decoded) : Mono.empty())
+			.map(URI::create)
+			.onErrorResume(IllegalArgumentException.class, (ex) -> Mono.empty());
+	}
+
+	private boolean isRelativePath(String uri) {
+		return uri.startsWith("/") && !uri.startsWith("//");
 	}
 
 	@Override
@@ -125,11 +131,13 @@ public class CookieServerRequestCache implements ServerRequestCache {
 	}
 
 	private static String encodeCookie(String cookieValue) {
-		return new String(Base64.getEncoder().encode(cookieValue.getBytes()));
+		return new String(Base64.getEncoder().encode(cookieValue.getBytes(StandardCharsets.UTF_8)),
+				StandardCharsets.UTF_8);
 	}
 
 	private static String decodeCookie(String encodedCookieValue) {
-		return new String(Base64.getDecoder().decode(encodedCookieValue.getBytes()));
+		return new String(Base64.getDecoder().decode(encodedCookieValue.getBytes(StandardCharsets.UTF_8)),
+				StandardCharsets.UTF_8);
 	}
 
 	private static ServerWebExchangeMatcher createDefaultRequestMatcher() {

--- a/web/src/test/java/org/springframework/security/web/authentication/preauth/x509/SubjectDnX509PrincipalExtractorTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/preauth/x509/SubjectDnX509PrincipalExtractorTests.java
@@ -74,6 +74,13 @@ public class SubjectDnX509PrincipalExtractorTests {
 		assertThat(principal).isEqualTo("Duke");
 	}
 
+	// gh-19254
+	@Test
+	public void defaultCNPatternReturnsMostSpecificPrincipalWhenMultipleCns() throws Exception {
+		Object principal = this.extractor.extractPrincipal(X509TestUtils.buildTestCertificateWithMultipleCns());
+		assertThat(principal).isEqualTo("alice");
+	}
+
 	@Test
 	public void setMessageSourceWhenNullThenThrowsException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.extractor.setMessageSource(null));

--- a/web/src/test/java/org/springframework/security/web/authentication/preauth/x509/SubjectX500PrincipalExtractorTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/preauth/x509/SubjectX500PrincipalExtractorTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2004-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.preauth.x509;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for {@link SubjectX500PrincipalExtractor}.
+ *
+ * @author Max Batischev
+ */
+public class SubjectX500PrincipalExtractorTests {
+
+	private final SubjectX500PrincipalExtractor extractor = new SubjectX500PrincipalExtractor();
+
+	@Test
+	void extractWhenCnPatternSetThenExtractsPrincipalName() throws Exception {
+		Object principal = this.extractor.extractPrincipal(X509TestUtils.buildTestCertificate());
+
+		assertThat(principal).isEqualTo("Luke Taylor");
+	}
+
+	@Test
+	void extractWhenEmailPatternSetThenExtractsPrincipalName() throws Exception {
+		this.extractor.setExtractPrincipalNameFromEmail(true);
+
+		Object principal = this.extractor.extractPrincipal(X509TestUtils.buildTestCertificate());
+
+		assertThat(principal).isEqualTo("luke@monkeymachine");
+	}
+
+	@Test
+	void extractWhenCnAtEndThenExtractsPrincipalName() throws Exception {
+		Object principal = this.extractor.extractPrincipal(X509TestUtils.buildTestCertificateWithCnAtEnd());
+
+		assertThat(principal).isEqualTo("Duke");
+	}
+
+	@Test
+	void extractWhenDnEmbeddedInCnThenExtractsPrincipalName() throws Exception {
+		Object principal = this.extractor.extractPrincipal(X509TestUtils.buildTestCertficateWithEmbeddedDn());
+
+		assertThat(principal).isEqualTo("luke");
+	}
+
+	// gh-19254
+	@Test
+	void extractWhenMultipleCnsThenExtractsMostSpecificCn() throws Exception {
+		Object principal = this.extractor.extractPrincipal(X509TestUtils.buildTestCertificateWithMultipleCns());
+
+		assertThat(principal).isEqualTo("alice");
+	}
+
+	@Test
+	void extractWhenEmailDnEmbeddedInCnThenExtractsEmail() throws Exception {
+		this.extractor.setExtractPrincipalNameFromEmail(true);
+
+		Object principal = this.extractor.extractPrincipal(X509TestUtils.buildTestCertficateWithEmbeddedEmailDn());
+
+		assertThat(principal).isEqualTo("luke@monkeymachine");
+	}
+
+	@Test
+	void setMessageSourceWhenNullThenThrowsException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.extractor.setMessageSource(null));
+	}
+
+	@Test
+	void extractWhenCertificateIsNullThenFails() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.extractor.extractPrincipal(null));
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/authentication/preauth/x509/X509TestUtils.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/preauth/x509/X509TestUtils.java
@@ -135,4 +135,88 @@ public final class X509TestUtils {
 		return (X509Certificate) cf.generateCertificate(in);
 	}
 
+	public static X509Certificate buildTestCertficateWithEmbeddedDn() throws Exception {
+		String cert = "-----BEGIN CERTIFICATE-----\n"
+				+ "MIIDDTCCAfWgAwIBAgIJANSyvk4gJhqPMA0GCSqGSIb3DQEBCwUAMEYxDTALBgNV\n"
+				+ "BAMMBGx1a2UxETAPBgNVBAsMCENOPWR1a2UsMRUwEwYDVQQKDAxFeGFtcGxlIENv\n"
+				+ "cnAxCzAJBgNVBAYTAlVTMB4XDTI2MDEwNDE5MjY0N1oXDTI3MDEwNTE5MjY0N1ow\n"
+				+ "RjENMAsGA1UEAwwEbHVrZTERMA8GA1UECwwIQ049ZHVrZSwxFTATBgNVBAoMDEV4\n"
+				+ "YW1wbGUgQ29ycDELMAkGA1UEBhMCVVMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw\n"
+				+ "ggEKAoIBAQDU9fY74nEFbBKfIef7CK02J/BJb42sIF9kD8eHN5OvEwLQBeTh30it\n"
+				+ "E7LLalXyOXeUFkPe1N1ZhGdVak9udsIqULSvQaWqTbN+IrAGklZAxuXYTC1GbhMF\n"
+				+ "AkGWWM55J2SNqVGQaHzZUn6VPxWaDft6nZR0DxuvXMYM5kVG6VErdB3ygGUv8cjQ\n"
+				+ "QBKAYpsZeRldnauRPt2dImmGTagvSuJVyr8X/AioE2Rl0guii456AKw+QSvRiZ+g\n"
+				+ "w08Y8C9nDyzQmurqpdYYkp0X+4yqm1iVowMX+tSPvHnlqJdvVzaW2b0yRzrrT6ao\n"
+				+ "UCgw25slR1P1IcyzqPKWQIoQRnYIaX1bAgMBAAEwDQYJKoZIhvcNAQELBQADggEB\n"
+				+ "AIos+nr8DFM6bAt9AI/79O/12hcN7gVv4F3P4Vz6NRRkkvsb9WMN8fLLDEsEJ/BQ\n"
+				+ "eQkAVnhlmAe++vrqy8OTHoQ7F5C3K0zrr19NLNoyNFTkXkFgnm4ZhYinSbusuIb7\n"
+				+ "LPYoyCnEEiMdl0VMWWSWcOvZpipbvTtH3CiVxTqXLjFFNraEAyUN50kXjo/zuHpK\n"
+				+ "HzTS1BAu0li9GdV3Da2ELdDx90zaUym7dDIejY4YUlXYIJ5UUYS61fqtgOHGLLdb\n"
+				+ "UXGAr5gqEe7OrQ9D4ebg9w5ciTb7g1H2CmirjTf/rkii8AojmsGFKIfGVe3gY6EB\n" + "o9eF5FV9V9leo5yLo25ev08=\n"
+				+ "-----END CERTIFICATE-----";
+		ByteArrayInputStream in = new ByteArrayInputStream(cert.getBytes());
+		CertificateFactory cf = CertificateFactory.getInstance("X.509");
+		return (X509Certificate) cf.generateCertificate(in);
+	}
+
+	public static X509Certificate buildTestCertficateWithEmbeddedEmailDn() throws Exception {
+		String cert = "-----BEGIN CERTIFICATE-----\n"
+				+ "MIIDfDCCAmSgAwIBAgIIXHoOUFeZ29MwDQYJKoZIhvcNAQELBQAwfjEhMB8GCSqG\n"
+				+ "SIb3DQEJARYSbHVrZUBtb25rZXltYWNoaW5lMTUwMwYDVQQLDCxPSUQuMS4yLjg0\n"
+				+ "MC4xMTM1NDkuMS45LjE9ZHVrZUBnb3JpbGxhZ2FkZ2V0LDEVMBMGA1UECgwMRXhh\n"
+				+ "bXBsZSBDb3JwMQswCQYDVQQGEwJVUzAeFw0yNjAxMDQxOTMxMDhaFw0yNzAxMDUx\n"
+				+ "OTMxMDhaMH4xITAfBgkqhkiG9w0BCQEWEmx1a2VAbW9ua2V5bWFjaGluZTE1MDMG\n"
+				+ "A1UECwwsT0lELjEuMi44NDAuMTEzNTQ5LjEuOS4xPWR1a2VAZ29yaWxsYWdhZGdl\n"
+				+ "dCwxFTATBgNVBAoMDEV4YW1wbGUgQ29ycDELMAkGA1UEBhMCVVMwggEiMA0GCSqG\n"
+				+ "SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDBuIQWnj+uvvG+4ZIyFMs4dSbiBavubCmC\n"
+				+ "hudrHr93hP19QbPulbHRTVCUqEi8efvq+J9jmMdPd7tziuDX02PeG9uljp9+c5Ir\n"
+				+ "pw9/oMoTRkF7K4PK1JxLN4tcgxjxVA4QkS+MjKLPeHrYyGCjKspcHbi+zBiQ9Xqp\n"
+				+ "yHWq6N5XPd6mEj2gh0zamnsJCeUCOX4SJbcp3MFtcYzhguHAeVhy9Jv+EAMJejDn\n"
+				+ "YIZmMUdP6Ykf2zTzs/4L3bRZb0oS5WvfeRdJB6SKg8mNO/jdGX87krSio//cRdDy\n"
+				+ "TGQK+YCVDf8GyLLavYZW56AJbZxL3MWgHYilQjj4p+Kw/PWpaBVvAgMBAAEwDQYJ\n"
+				+ "KoZIhvcNAQELBQADggEBAKVTMIo8JO0H0HRrpsEDP17E2pnfMJV4g70BwClUMMek\n"
+				+ "wNIWZn+6XPR8oObzzjnVWXjrovMkmmyFk0vWIpF68MPyiQ++5fwdzOZiQtUP177n\n"
+				+ "9ulAtLoIJld3olGeL9VsCZGp3J2PqiDe613zd+bkSUG1lQYC2awozWqJEdvwJJtf\n"
+				+ "j9nlhyMsARKEEu3tFGJsCHST3XhbhFKOraf/GZ21xW650R7ap0ZNaEiB16M2a5Oe\n"
+				+ "WXasgUukIo82Z8+yK4IITeCcr0aA1fJxwhU8J6qfYWloaoirSYj487HRnPPv3X/b\n"
+				+ "RxZynIjtGKygT6T1dRaWennmoitqfprJnEO2tlhLwP0=\n" + "-----END CERTIFICATE-----";
+		ByteArrayInputStream in = new ByteArrayInputStream(cert.getBytes());
+		CertificateFactory cf = CertificateFactory.getInstance("X.509");
+		return (X509Certificate) cf.generateCertificate(in);
+	}
+
+	/**
+	 * Builds an X.509 certificate whose subject contains more than one CN. The subject DN
+	 * is:
+	 *
+	 * <pre>
+	 *  CN=alice, CN=bob, O=Example Corp, C=US
+	 * </pre>
+	 *
+	 * where {@code CN=alice} is the most specific (left-most) RDN.
+	 */
+	public static X509Certificate buildTestCertificateWithMultipleCns() throws Exception {
+		String cert = "-----BEGIN CERTIFICATE-----\n"
+				+ "MIIDJzCCAg+gAwIBAgIIclOz1VulWC8wDQYJKoZIhvcNAQEMBQAwQjELMAkGA1UE\n"
+				+ "BhMCVVMxFTATBgNVBAoTDEV4YW1wbGUgQ29ycDEMMAoGA1UEAxMDYm9iMQ4wDAYD\n"
+				+ "VQQDEwVhbGljZTAeFw0yNjA2MDExOTQzMTVaFw0zNjA1MjkxOTQzMTVaMEIxCzAJ\n"
+				+ "BgNVBAYTAlVTMRUwEwYDVQQKEwxFeGFtcGxlIENvcnAxDDAKBgNVBAMTA2JvYjEO\n"
+				+ "MAwGA1UEAxMFYWxpY2UwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCX\n"
+				+ "q8hZrTRHJEN7+D6yK65OKeCTVU+WccI6awz6g4T6O3aoC+1IiUljsEYn+xuDfx5L\n"
+				+ "L/O1kejjmbYt+vzRmiILoJ9xKfW3ERcB4+gEar959Dkj6wmpsgOKRjmOvcOFOkEe\n"
+				+ "gU1F7t04JHOou3DaAkHMNMQV+3jsWSh9Rry7XZBDkcT8XbbagoCgSIIef03Qtw31\n"
+				+ "zOBwqmJmd6CQhFJva5cl8cCE2xZinOIiz/2j7VprZTjhkud2M4bRnK3T0WExyOCg\n"
+				+ "jvjSf5ZoOKwC2Z9Q/Oyf8WKpren1+GfZhAKKmn7QZ2foHhdPPRtNjRGE6SqQyW2u\n"
+				+ "8+1tOXl+aRCF19rR7gIpAgMBAAGjITAfMB0GA1UdDgQWBBRfLtnK5WKU0q3zxIrr\n"
+				+ "y3GD+lYplzANBgkqhkiG9w0BAQwFAAOCAQEAe+/FHqErVPsF/sHrVHny8mIsn3ux\n"
+				+ "qE9P24KNF0oIfmBrAqqge6hoVQ8PS+JialyqFf//osuDjiuYaBEKBw7GCoA6I8mr\n"
+				+ "FA7wyFaGosfq7An5vxkJl7lap2u5oSVv3dCy13Bs0ziYmNlTkfHDLy9yh7jpH1wg\n"
+				+ "TvylH9O4Vc7y9rzzpIjMCuQJ/wJ4MuJ2mSarYZsx3UQHIRfpKtR/9jbFMX1Rbv/A\n"
+				+ "N0XD+NrtFjiikp71y3aCO1EHnGG7qPKCWh3PzaNoWFpyZKDBvud8ymW7RMiLPgv9\n"
+				+ "eTa82KGgnCwtKCNzGkszIn7fza/6xnCuzvh4y9tYE5BWP2mcMRtRmDD07w==\n" + "-----END CERTIFICATE-----";
+		ByteArrayInputStream in = new ByteArrayInputStream(cert.getBytes());
+		CertificateFactory cf = CertificateFactory.getInstance("X.509");
+		return (X509Certificate) cf.generateCertificate(in);
+	}
+
 }

--- a/web/src/test/java/org/springframework/security/web/savedrequest/CookieRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/savedrequest/CookieRequestCacheTests.java
@@ -54,7 +54,7 @@ public class CookieRequestCacheTests {
 		Cookie savedCookie = response.getCookie(DEFAULT_COOKIE_NAME);
 		assertThat(savedCookie).isNotNull();
 		String redirectUrl = decodeCookie(savedCookie.getValue());
-		assertThat(redirectUrl).isEqualTo("https://abc.com/destination?param1=a&param2=b&param3=1122");
+		assertThat(redirectUrl).isEqualTo("/destination?param1=a&param2=b&param3=1122");
 		assertThat(savedCookie.getMaxAge()).isEqualTo(-1);
 		assertThat(savedCookie.getPath()).isEqualTo("/");
 		assertThat(savedCookie.isHttpOnly()).isTrue();
@@ -101,11 +101,61 @@ public class CookieRequestCacheTests {
 	public void getRequestWhenRequestContainsSavedRequestCookieThenReturnsSaveRequest() {
 		CookieRequestCache cookieRequestCache = new CookieRequestCache();
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		String redirectUrl = "https://abc.com/destination?param1=a&param2=b&param3=1122";
-		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie(redirectUrl)));
+		request.setScheme("https");
+		request.setServerName("abc.com");
+		request.setServerPort(443);
+		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie("/destination?param1=a&param2=b&param3=1122")));
 		SavedRequest savedRequest = cookieRequestCache.getRequest(request, new MockHttpServletResponse());
 		assertThat(savedRequest).isNotNull();
-		assertThat(savedRequest.getRedirectUrl()).isEqualTo(redirectUrl);
+		assertThat(savedRequest.getRedirectUrl())
+			.isEqualTo("https://abc.com/destination?param1=a&param2=b&param3=1122");
+	}
+
+	@Test
+	public void getRequestWhenRelativePathInCookieThenRedirectUrlUsesCurrentRequestOrigin() {
+		CookieRequestCache cookieRequestCache = new CookieRequestCache();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setScheme("https");
+		request.setServerName("myapp.com");
+		request.setServerPort(443);
+		request.setSecure(true);
+		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie("/secret?token=abc")));
+		SavedRequest savedRequest = cookieRequestCache.getRequest(request, new MockHttpServletResponse());
+		assertThat(savedRequest).isNotNull();
+		assertThat(savedRequest.getRedirectUrl()).isEqualTo("https://myapp.com/secret?token=abc");
+	}
+
+	@Test
+	public void getRequestWhenAbsoluteUrlInCookieThenReturnsNull() {
+		CookieRequestCache cookieRequestCache = new CookieRequestCache();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie("https://evil.com/phishing")));
+		SavedRequest savedRequest = cookieRequestCache.getRequest(request, new MockHttpServletResponse());
+		assertThat(savedRequest).isNull();
+	}
+
+	@Test
+	public void getRequestWhenProtocolRelativeUrlInCookieThenReturnsNull() {
+		CookieRequestCache cookieRequestCache = new CookieRequestCache();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie("//evil.com/phishing")));
+		SavedRequest savedRequest = cookieRequestCache.getRequest(request, new MockHttpServletResponse());
+		assertThat(savedRequest).isNull();
+	}
+
+	@Test
+	public void getRequestWhenRequestContainsSavedRequestCookieThenSavedRequestContainsRequestParameters() {
+		CookieRequestCache cookieRequestCache = new CookieRequestCache();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie("/destination")));
+		request.setParameter("single", "first");
+		request.addParameter("multi", "second");
+		request.addParameter("multi", "third");
+		SavedRequest savedRequest = cookieRequestCache.getRequest(request, new MockHttpServletResponse());
+		assertThat(savedRequest).isNotNull();
+		assertThat(savedRequest.getParameterValues("single")).containsExactly("first");
+		assertThat(savedRequest.getParameterValues("multi")).containsExactly("second", "third");
+		assertThat(savedRequest.getParameterMap()).containsKeys("single", "multi");
 	}
 
 	@Test
@@ -128,8 +178,7 @@ public class CookieRequestCacheTests {
 		request.setServerName("abc.com");
 		request.setRequestURI("/destination");
 		request.setQueryString("param1=a&param2=b&param3=1122");
-		String redirectUrl = "https://abc.com/destination?param1=a&param2=b&param3=1122";
-		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie(redirectUrl)));
+		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie("/destination?param1=a&param2=b&param3=1122")));
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		cookieRequestCache.getMatchingRequest(request, response);
 		Cookie expiredCookie = response.getCookie(DEFAULT_COOKIE_NAME);
@@ -147,8 +196,7 @@ public class CookieRequestCacheTests {
 		request.setScheme("https");
 		request.setServerName("abc.com");
 		request.setRequestURI("/destination");
-		String redirectUrl = "https://abc.com/api";
-		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie(redirectUrl)));
+		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie("/api")));
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		final HttpServletRequest matchingRequest = cookieRequestCache.getMatchingRequest(request, response);
 		assertThat(matchingRequest).isNull();
@@ -167,8 +215,8 @@ public class CookieRequestCacheTests {
 		request.setRequestURI("/destination");
 		request.setQueryString("goto=https%3A%2F%2Fstart.spring.io");
 		request.setParameter("goto", "https://start.spring.io");
-		String redirectUrl = "https://abc.com/destination?goto=https%3A%2F%2Fstart.spring.io";
-		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie(redirectUrl)));
+		request.setCookies(
+				new Cookie(DEFAULT_COOKIE_NAME, encodeCookie("/destination?goto=https%3A%2F%2Fstart.spring.io")));
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		final HttpServletRequest matchingRequest = cookieRequestCache.getMatchingRequest(request, response);
 		assertThat(matchingRequest).isNotNull();
@@ -197,7 +245,7 @@ public class CookieRequestCacheTests {
 		request.setServerName("example.com");
 		request.setRequestURI("/destination");
 		request.setPreferredLocales(Arrays.asList(Locale.FRENCH, Locale.GERMANY));
-		String redirectUrl = "https://example.com/destination";
+		String redirectUrl = "/destination";
 		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, encodeCookie(redirectUrl)));
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		HttpServletRequest matchingRequest = cookieRequestCache.getMatchingRequest(request, response);

--- a/web/src/test/java/org/springframework/security/web/savedrequest/RequestCacheAwareFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/savedrequest/RequestCacheAwareFilterTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.security.web.savedrequest;
 
-import java.util.Base64;
-
 import javax.servlet.http.Cookie;
 
 import org.junit.jupiter.api.Test;
@@ -52,14 +50,15 @@ public class RequestCacheAwareFilterTests {
 		request.setScheme("https");
 		request.setServerPort(443);
 		request.setSecure(true);
-		String encodedRedirectUrl = Base64.getEncoder().encodeToString("https://abc.com/destination".getBytes());
-		Cookie savedRequest = new Cookie("REDIRECT_URI", encodedRedirectUrl);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		cache.saveRequest(request, response);
+		Cookie savedRequest = response.getCookie("REDIRECT_URI");
 		savedRequest.setMaxAge(-1);
 		savedRequest.setSecure(request.isSecure());
 		savedRequest.setPath("/");
 		savedRequest.setHttpOnly(true);
 		request.setCookies(savedRequest);
-		MockHttpServletResponse response = new MockHttpServletResponse();
+		response = new MockHttpServletResponse();
 		filter.doFilter(request, response, new MockFilterChain());
 		Cookie expiredCookie = response.getCookie("REDIRECT_URI");
 		assertThat(expiredCookie).isNotNull();

--- a/web/src/test/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCacheTests.java
@@ -118,6 +118,26 @@ public class CookieServerRequestCacheTests {
 	}
 
 	@Test
+	public void getRedirectUriWhenCookieContainsAbsoluteUrlThenRedirectUriIsNull() {
+		String encodedAbsoluteUrl = Base64.getEncoder().encodeToString("https://evil.com/phishing".getBytes());
+		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/login")
+			.accept(MediaType.TEXT_HTML)
+			.cookie(new HttpCookie("REDIRECT_URI", encodedAbsoluteUrl)));
+		URI redirectUri = this.cache.getRedirectUri(exchange).block();
+		assertThat(redirectUri).isNull();
+	}
+
+	@Test
+	public void getRedirectUriWhenCookieContainsProtocolRelativeUrlThenRedirectUriIsNull() {
+		String encodedProtocolRelativeUrl = Base64.getEncoder().encodeToString("//evil.com/phishing".getBytes());
+		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/login")
+			.accept(MediaType.TEXT_HTML)
+			.cookie(new HttpCookie("REDIRECT_URI", encodedProtocolRelativeUrl)));
+		URI redirectUri = this.cache.getRedirectUri(exchange).block();
+		assertThat(redirectUri).isNull();
+	}
+
+	@Test
 	public void getRedirectUriWhenNoCookieThenRedirectUriIsNull() {
 		MockServerWebExchange exchange = MockServerWebExchange
 			.from(MockServerHttpRequest.get("/secured/").accept(MediaType.TEXT_HTML));


### PR DESCRIPTION
## Summary

  Back-ports 5 Snyk-flagged Spring Security CVEs into the `5.8.x` fork (base
  `5.8.16-rxlogix-2` → `5.8.16-rxlogix-3`). 5.8.x is EOL upstream (public OSS support ends
  at 5.8.16; the 5.8.x fixes upstream are Enterprise-only), so fixes are taken from
  `spring-projects/spring-security` (present in tags `6.5.11` / `7.0.6`) and adapted to the
  fork: **Java 8**, **`javax.servlet`**, and the fork's dual `opensaml3Main`/`opensaml4Main`
  SAML source-set layout.

  ⚠️  **Security review requested** — touches authentication, cryptography and PII handling
  (X.509 identity, SAML signature/decryption).

  Parent epic: PVADMIN-50285 · Task: PVADMIN-50329 · Fix Version: 7.1.2

  ## CVE details

  ### CVE-2026-41706 — Open Redirect (Medium, CVSS 5.1) — `spring-security-web`
  `CookieRequestCache`/`CookieServerRequestCache` stored the full absolute URL in the
  `REDIRECT_URI` cookie and used it unvalidated. Now stores a relative URI and rejects
  non-relative cookie values, rebuilding scheme/host/port from the request.
  Cherry-pick of `a14c9d66b15946d2040a3681b55fe29ac145c5c9`.
  *Fork note:* re-added `DefaultSavedRequest.Builder#setParameters(request.getParameterMap())`
  to `getRequest()` (predated the upstream commit, so not carried by the cherry-pick).

  ### CVE-2026-41003 — XSS (Medium, CVSS 6.1) — `spring-security-saml2-service-provider`
  The SAML POST auto-submit form embedded an unescaped form `action` URI. Now
  HTML-escapes it in the three rendering filters (`Saml2WebSsoAuthenticationRequestFilter`,
  `Saml2LogoutRequestFilter`, `Saml2RelyingPartyInitiatedLogoutSuccessHandler`).
  Equivalent to upstream `356131b1ea6eede0c5306affab654f83a50d6bc9` (which introduced
  `FormPostRedirectStrategy`); applied as the minimal escape since that new helper has no
  other consumer on this line (OIDC POST-logout is not in 5.8.x).

  ### CVE-2026-40988 — Data amplification / zip-bomb DoS (High, CVSS 8.7) — `spring-security-saml2-service-provider`
  SAML REDIRECT-binding inflate had no decompressed-size bound. Wraps the inflater in a
  `CappedOutputStream` (1 MB) across the fork's 4 `Saml2Utils` copies.
  Cherry-pick of `9d4d9065b48508c9e115f2f894632120787fd1df` (removed the 4 upstream-only
  packages absent on the fork; relocated the new test to `provider.service.authentication`).

  ### CVE-2026-41694 — Decryption oracle (Medium, CVSS 6.3) — `spring-security-saml2-service-provider`
  Encrypted SAML elements (EncryptedID in LogoutRequest, EncryptedAssertion in Response)
  were decrypted before signature verification. Now verifies signature first and never
  decrypts unverified input. **Required two upstream commits** (Snyk listed only the first):
  `cf0687120024c3dad09261dd9df4971b83717a53` (logout) + `e50c2a6a74d5e25d90d114a665ccd1c83cb6a6f4`
  (login/Response). Manual port to the logout validators (shared `main`) and both auth
  providers (`opensaml3Main` + `opensaml4Main`).

  ### CVE-2026-47838 — User impersonation via X.509 CN (High, CVSS 7.6) — `spring-security-web`
  A crafted CN could be mis-parsed by the regex-based `SubjectDnX509PrincipalExtractor`.
  New `SubjectX500PrincipalExtractor` parses the DN via `LdapName`/`Rdn` (most-specific
  first) and is now the servlet + reactive default; old extractor deprecated.
  Manual port of the security subset of `e3ad551ab337d8a1e17217994b45fed6c68ce69e` (dropped
  the 6.5 xsd/rnc schema, docs/Kotlin samples, and the new XML `principal-extractor-ref`
  feature — out of scope / absent on the fork).

  ## Conflict-resolution / adaptation notes
  - `jakarta.servlet` → `javax.servlet`; Java 8 syntax throughout.
  - SAML fixes mapped onto the fork's `opensaml3Main`/`opensaml4Main` layout (upstream uses
    `Base*`/`opensaml5` classes that don't exist here).
  - CVE-2026-41694 tests: fixed `authenticateWhenDecryptionKeysAreWrong…` in both opensaml3/4
    test suites to wrap `verifying(registration())` (mirrors upstream `6.5.11`) — under the
    fix an unverifiable signature now correctly yields `invalid_signature` before decryption.

  ## Test plan
  - [x] `:spring-security-web` build + affected tests green (cookie caches, X509 extractors, FormPost N/A)
  - [x] `:spring-security-saml2-service-provider` `test` + `opensaml3Test` + `opensaml4Test` green (incl. new + adjusted tests)
  - [x] `:spring-security-config` `X509ConfigurerTests` 9/0/0
  - [x] New tests added for every CVE
  - [x] Reviewer: human security review (auth/crypto/PII)

  > ⚠️  Known pre-existing issue (NOT from this PR): `:spring-security-config:test` is
  > build-red on this fork because Gradle mis-detects SAML test *helper* inner classes
  > (e.g. `Saml2LoginConfigurerTests$ResourceController`) as test classes. Confirmed
  > identical on the clean base with these changes stashed. Affected test classes
  > themselves pass.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
